### PR TITLE
[REFACTOR] rename assignment_name attribute in request to name

### DIFF
--- a/assessment/services/assessment.py
+++ b/assessment/services/assessment.py
@@ -15,7 +15,7 @@ def get_assessor_or_raise_exception(user: User):
 
 
 def validate_assessment_tool(request_data):
-    if not request_data.get('assignment_name'):
+    if not request_data.get('name'):
         raise InvalidAssignmentRegistration('Assessment name should not be empty')
 
 
@@ -27,7 +27,7 @@ def validate_assignment(request_data):
 
 
 def save_assignment_to_database(request_data: dict, assessor: Assessor):
-    name = request_data.get('assignment_name')
+    name = request_data.get('name')
     description = request_data.get('description')
     owning_company = assessor.associated_company
     expected_file_format = utils.sanitize_file_format(request_data.get('expected_file_format'))

--- a/assessment/tests.py
+++ b/assessment/tests.py
@@ -41,14 +41,14 @@ class AssessmentTest(TestCase):
         )
 
         self.request_data = {
-            'assignment_name': 'Business Proposal Task 1',
+            'name': 'Business Proposal Task 1',
             'description': 'This is the first assignment',
             'duration_in_minutes': 55,
             'expected_file_format': '.pdf'
         }
 
         self.expected_assignment = Assignment(
-            name=self.request_data.get('assignment_name'),
+            name=self.request_data.get('name'),
             description=self.request_data.get('description'),
             owning_company=self.assessor.associated_company,
             expected_file_format='pdf',
@@ -99,7 +99,7 @@ class AssessmentTest(TestCase):
 
     def test_validate_assessment_tool_when_request_data_has_no_name(self):
         invalid_request_data = self.request_data.copy()
-        invalid_request_data['assignment_name'] = ''
+        invalid_request_data['name'] = ''
         expected_message = 'Assessment name should not be empty'
 
         try:

--- a/assessment/views.py
+++ b/assessment/views.py
@@ -13,7 +13,7 @@ import json
 def serve_create_assignment(request):
     """
     request_data must contain
-    assignment_name (string),
+    name (string),
     description (string),
     duration_in_minutes (integer),
     expected_file_format (string, without leading .)


### PR DESCRIPTION
Previous version uses assignment_name as the request parameter. However, this will make it hard to reuse the validation function for other assignment types. Hence, it is standardized to name.