### PR TITLE
[REFACTOR] change authorization exception response to forbidden

### DIFF
--- a/assessment/services/assessment_event_attempt.py
+++ b/assessment/services/assessment_event_attempt.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User
-from one_day_intern.exceptions import RestrictedAccessException, InvalidRequestException, AuthorizationException
+from one_day_intern.exceptions import RestrictedAccessException, InvalidRequestException
 from users.models import Assessee, Assessor
 from ..exceptions.exceptions import EventDoesNotExist
 from ..models import AssessmentEvent
@@ -41,10 +41,7 @@ def get_all_active_assignment(request_data: dict, user: User):
 
 
 def verify_assessee_participation(request_data, user: User):
-    try:
-        assessee = utils.get_assessee_from_user(user)
-    except AuthorizationException as exception:
-        raise RestrictedAccessException(str(exception))
+    assessee = utils.get_assessee_from_user(user)
 
     try:
         assessment_event = utils.get_assessment_event_from_id(request_data.get('assessment-event-id'))

--- a/assessment/services/utils.py
+++ b/assessment/services/utils.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import User
 from datetime import time, datetime
 from users.models import Company, Assessor, Assessee
-from one_day_intern.exceptions import RestrictedAccessException, AuthorizationException
+from one_day_intern.exceptions import RestrictedAccessException
 from ..models import TestFlow, AssessmentEvent
 from ..exceptions.exceptions import AssessmentToolDoesNotExist, TestFlowDoesNotExist, EventDoesNotExist
 
@@ -118,4 +118,4 @@ def get_assessee_from_user(user: User) -> Assessee:
     if found_assessees:
         return found_assessees[0]
     else:
-        raise AuthorizationException(f'User with email {user.email} is not an assessee')
+        raise RestrictedAccessException(f'User with email {user.email} is not an assessee')

--- a/assessment/tests.py
+++ b/assessment/tests.py
@@ -1982,7 +1982,7 @@ class AssesseeSubscribeToAssessmentEvent(TestCase):
             assessment_event_id=self.assessment_event.event_id
         )
 
-        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         response_content = json.loads(response.content)
         self.assertEqual(
             response_content.get('message'),

--- a/assessment/views.py
+++ b/assessment/views.py
@@ -11,7 +11,7 @@ from assessment.services.assessment_tool import (
     serialize_test_flow_list
 )
 from .services.assessment import create_assignment, create_interactive_quiz
-from one_day_intern.exceptions import AuthorizationException, RestrictedAccessException
+from one_day_intern.exceptions import RestrictedAccessException
 from users.services import utils as user_utils
 from .services.test_flow import create_test_flow
 from .services.assessment_event import create_assessment_event, add_assessment_event_participation
@@ -23,6 +23,7 @@ from .services.assessment_event_attempt import (
 from .models import AssignmentSerializer, TestFlowSerializer, AssessmentEventSerializer, InteractiveQuizSerializer
 import json
 
+
 @require_GET
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
@@ -31,6 +32,7 @@ def serve_get_assessment_tool(request):
     response_data = serialize_assignment_list_using_serializer(assignments)
     return Response(data=response_data)
 
+
 @require_GET
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
@@ -38,6 +40,7 @@ def serve_get_test_flow(request):
     test_flows = get_test_flow_by_company(request.user)
     response_data = serialize_test_flow_list(test_flows)
     return Response(data=response_data)
+
 
 @require_POST
 @api_view(['POST'])
@@ -159,12 +162,9 @@ def serve_subscribe_to_assessment_flow(request):
         user = user_utils.get_user_from_request(request)
         task_generator = subscribe_to_assessment_flow(request_data, user=user)
         return StreamingHttpResponse(task_generator.generate(), status=200, content_type='text/event-stream')
-    except AuthorizationException as exception:
-        response_content = {'message': str(exception)}
-        return HttpResponse(content=json.dumps(response_content), status=403)
     except RestrictedAccessException as exception:
         response_content = {'message': str(exception)}
-        return HttpResponse(content=json.dumps(response_content), status=401)
+        return HttpResponse(content=json.dumps(response_content), status=403)
     except ObjectDoesNotExist as exception:
         response_content = {'message': str(exception)}
         return HttpResponse(content=json.dumps(response_content), status=400)

--- a/assessor/services/utils.py
+++ b/assessor/services/utils.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import User
-
-from one_day_intern.exceptions import AuthorizationException
+from one_day_intern.exceptions import RestrictedAccessException
 from users.models import Assessor
 
 
@@ -10,4 +9,4 @@ def get_assessor_from_user(user: User) -> Assessor:
     if found_assessors:
         return found_assessors[0]
     else:
-        raise AuthorizationException(f'User with email {user.email} is not an assessor')
+        raise RestrictedAccessException(f'User with email {user.email} is not an assessor')

--- a/assessor/tests.py
+++ b/assessor/tests.py
@@ -147,7 +147,7 @@ class ActiveAssessmentToolTest(TestCase):
             event_id=str(self.assessment_event.event_id),
             authenticated_user=self.assessee_1
         )
-        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         response_content = json.loads(response.content)
         self.assertEqual(
             response_content.get('message'),

--- a/one_day_intern/exception_config.py
+++ b/one_day_intern/exception_config.py
@@ -3,8 +3,7 @@ from rest_framework.response import Response
 from .exceptions import (
     RestrictedAccessException,
     InvalidRequestException,
-    InvalidRegistrationException,
-    AuthorizationException
+    InvalidRegistrationException
 )
 
 
@@ -15,8 +14,6 @@ def custom_exception_handler(exception, context):
 
     if isinstance(exception, InvalidRegistrationException) or isinstance(exception, InvalidRequestException):
         status_code = 400
-    elif isinstance(exception, AuthorizationException):
-        status_code = 401
     elif isinstance(exception, RestrictedAccessException):
         status_code = 403
     else:

--- a/one_day_intern/exceptions.py
+++ b/one_day_intern/exceptions.py
@@ -30,9 +30,5 @@ class InvalidGoogleIDTokenException(Exception):
     pass
 
 
-class AuthorizationException(Exception):
-    pass
-
-
 class InvalidGoogleLoginException(Exception):
     pass


### PR DESCRIPTION
Previously, if a user already login but failed to gain authorization to a certain service, an AuthorizationException with status 401 will be raised. However, this conflicts with the front end mechanism to refetch the access and refresh token. This commit changes all previously AuthorizationException to RestrictedAccessException and changes the response code from UNAUTHORIZED to FORBIDDEN.