### PR TITLE
PBI-07 Company Assessor Login

### DIFF
--- a/assessment/models.py
+++ b/assessment/models.py
@@ -444,11 +444,11 @@ class AssessmentEventSerializer(serializers.ModelSerializer):
     end_date_time = serializers.SerializerMethodField(method_name='get_end_time_iso')
     start_date_time = serializers.SerializerMethodField(method_name='get_start_time_iso')
 
-    def get_end_time_iso(obj, self):
-        return self.get_event_end_date_time().isoformat()
+    def get_end_time_iso(self, serialized_obj):
+        return serialized_obj.get_event_end_date_time().isoformat()
 
-    def get_start_time_iso(obj, self):
-        return self.start_date_time.isoformat()
+    def get_start_time_iso(self, serialized_obj):
+        return serialized_obj.start_date_time.isoformat()
 
     class Meta:
         model = AssessmentEvent

--- a/assessment/tests.py
+++ b/assessment/tests.py
@@ -2451,7 +2451,7 @@ class AssignmentSubmissionTest(TestCase):
 
         self.assignment = Assignment.objects.create(
             name='Esai Singkat: The Power of Social Media',
-            description='Kerjakan sesuai pemahaman Anda',
+            description='Kerjakan sesuai pemahaman Anda 2454',
             owning_company=self.company,
             expected_file_format='pdf',
             duration_in_minutes=120
@@ -3028,7 +3028,7 @@ class ActiveAssignmentTest(TestCase):
 
         self.assignment = Assignment.objects.create(
             name='Esai Singkat: The Power of Mass Media',
-            description='Kerjakan sesuai pemahaman Anda',
+            description='Kerjakan sesuai pemahaman Anda 3031',
             owning_company=self.company,
             expected_file_format='pdf',
             duration_in_minutes=120
@@ -3228,7 +3228,7 @@ class AssessmentToolDeadlineTest(TestCase):
 
         self.assignment = Assignment.objects.create(
             name='Esai Singkat: Menilik G20 untuk Perusahaan Tuitter',
-            description='Kerjakan sesuai pemahaman Anda',
+            description='Kerjakan sesuai pemahaman Anda 3231',
             owning_company=self.company,
             expected_file_format='pdf',
             duration_in_minutes=120

--- a/one_day_intern/exception_config.py
+++ b/one_day_intern/exception_config.py
@@ -3,7 +3,8 @@ from rest_framework.response import Response
 from .exceptions import (
     RestrictedAccessException,
     InvalidRequestException,
-    InvalidRegistrationException
+    InvalidRegistrationException,
+    InvalidLoginCredentialsException
 )
 
 
@@ -12,8 +13,10 @@ def custom_exception_handler(exception, context):
     if response is not None:
         return response
 
-    if isinstance(exception, InvalidRegistrationException) or isinstance(exception, InvalidRequestException):
+    if isinstance(exception, (InvalidRegistrationException, InvalidRequestException)):
         status_code = 400
+    elif isinstance(exception, InvalidLoginCredentialsException):
+        status_code = 401
     elif isinstance(exception, RestrictedAccessException):
         status_code = 403
     else:

--- a/one_day_intern/exceptions.py
+++ b/one_day_intern/exceptions.py
@@ -32,5 +32,10 @@ class InvalidGoogleIDTokenException(Exception):
 class InvalidGoogleLoginException(Exception):
     pass
 
+
 class InvalidResponseTestRegistration(Exception):
+    pass
+
+
+class InvalidLoginCredentialsException(Exception):
     pass

--- a/users/services/login.py
+++ b/users/services/login.py
@@ -14,3 +14,7 @@ def get_assessor_or_company_from_request_data(request_data):
         return utils.get_assessor_or_company_from_email(request_data.get('email'))
     except ObjectDoesNotExist as exception:
         raise InvalidLoginCredentialsException(exception)
+
+
+def login_assessor_company(request_data):
+    return None

--- a/users/services/login.py
+++ b/users/services/login.py
@@ -1,0 +1,5 @@
+from django.contrib.auth.models import User
+
+
+def verify_password(user: User, password: str):
+    raise Exception

--- a/users/services/login.py
+++ b/users/services/login.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.models import User
+from one_day_intern.exceptions import InvalidLoginCredentialsException
 
 
 def verify_password(user: User, password: str):
-    raise Exception
+    if not user.check_password(password):
+        raise InvalidLoginCredentialsException(f'Password for {user.email} is invalid')

--- a/users/services/login.py
+++ b/users/services/login.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
 from one_day_intern.exceptions import InvalidLoginCredentialsException
+from . import utils
 
 
 def verify_password(user: User, password: str):
@@ -8,4 +10,7 @@ def verify_password(user: User, password: str):
 
 
 def get_assessor_or_company_from_request_data(request_data):
-    raise Exception
+    try:
+        return utils.get_assessor_or_company_from_email(request_data.get('email'))
+    except ObjectDoesNotExist as exception:
+        raise InvalidLoginCredentialsException(exception)

--- a/users/services/login.py
+++ b/users/services/login.py
@@ -5,3 +5,7 @@ from one_day_intern.exceptions import InvalidLoginCredentialsException
 def verify_password(user: User, password: str):
     if not user.check_password(password):
         raise InvalidLoginCredentialsException(f'Password for {user.email} is invalid')
+
+
+def get_assessor_or_company_from_request_data(request_data):
+    raise Exception

--- a/users/services/login.py
+++ b/users/services/login.py
@@ -17,4 +17,7 @@ def get_assessor_or_company_from_request_data(request_data):
 
 
 def login_assessor_company(request_data):
-    return None
+    user = get_assessor_or_company_from_request_data(request_data)
+    verify_password(user, request_data.get('password'))
+    token = utils.generate_token_for_user(user)
+    return token

--- a/users/services/utils.py
+++ b/users/services/utils.py
@@ -4,6 +4,8 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken
 from datetime import datetime
 from typing import Optional, Match
+
+
 from ..models import Assessor, Company
 import phonenumbers
 import re
@@ -114,3 +116,7 @@ def get_assessor_or_company_from_email(email):
         return user
     else:
         raise ObjectDoesNotExist(f'Assessor or Company with email {email} not found')
+
+
+def generate_token_for_user(user):
+    return None

--- a/users/services/utils.py
+++ b/users/services/utils.py
@@ -95,3 +95,7 @@ def get_company_from_email(email):
         return Company.objects.get(email=email)
     except ObjectDoesNotExist:
         raise ObjectDoesNotExist(f'Company with email {email} not found')
+
+
+def get_assessor_or_company_from_email(email):
+    raise Exception

--- a/users/services/utils.py
+++ b/users/services/utils.py
@@ -4,7 +4,7 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken
 from datetime import datetime
 from typing import Optional, Match
-from ..models import Assessor
+from ..models import Assessor, Company
 import phonenumbers
 import re
 
@@ -88,3 +88,7 @@ def get_assessor_from_email(email):
         return Assessor.objects.get(email=email)
     except ObjectDoesNotExist:
         raise ObjectDoesNotExist(f'Assessor with email {email} not found')
+
+
+def get_company_from_email(email):
+    raise Exception

--- a/users/services/utils.py
+++ b/users/services/utils.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken
+from rest_framework_simplejwt.tokens import RefreshToken
 from datetime import datetime
 from typing import Optional, Match
 
@@ -119,4 +120,8 @@ def get_assessor_or_company_from_email(email):
 
 
 def generate_token_for_user(user):
-    return None
+    token: RefreshToken = RefreshToken.for_user(user)
+    return {
+        'refresh': str(token),
+        'access': str(token.access_token)
+    }

--- a/users/services/utils.py
+++ b/users/services/utils.py
@@ -1,8 +1,10 @@
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken
 from datetime import datetime
 from typing import Optional, Match
+from ..models import Assessor
 import phonenumbers
 import re
 
@@ -80,3 +82,6 @@ def get_user_from_request(request):
     except InvalidToken:
         return AnonymousUser()
 
+
+def get_assessor_from_email(email):
+    raise Exception

--- a/users/services/utils.py
+++ b/users/services/utils.py
@@ -91,4 +91,7 @@ def get_assessor_from_email(email):
 
 
 def get_company_from_email(email):
-    raise Exception
+    try:
+        return Company.objects.get(email=email)
+    except ObjectDoesNotExist:
+        raise ObjectDoesNotExist(f'Company with email {email} not found')

--- a/users/services/utils.py
+++ b/users/services/utils.py
@@ -98,4 +98,19 @@ def get_company_from_email(email):
 
 
 def get_assessor_or_company_from_email(email):
-    raise Exception
+    user = None
+
+    try:
+        user = get_company_from_email(email)
+    except ObjectDoesNotExist:
+        pass
+
+    try:
+        user = get_assessor_from_email(email)
+    except ObjectDoesNotExist:
+        pass
+
+    if user:
+        return user
+    else:
+        raise ObjectDoesNotExist(f'Assessor or Company with email {email} not found')

--- a/users/services/utils.py
+++ b/users/services/utils.py
@@ -84,4 +84,7 @@ def get_user_from_request(request):
 
 
 def get_assessor_from_email(email):
-    raise Exception
+    try:
+        return Assessor.objects.get(email=email)
+    except ObjectDoesNotExist:
+        raise ObjectDoesNotExist(f'Assessor with email {email} not found')

--- a/users/tests.py
+++ b/users/tests.py
@@ -32,6 +32,7 @@ PASSWORD_MUST_NOT_BE_NULL = 'Password must not be null'
 PASSWORD_INVALID_NO_UPPER = 'Password length must contain at least 1 uppercase character'
 EXCEPTION_NOT_RAISED = 'Exception not raised'
 ASSESSOR_WITH_EMAIL_NOT_EXIST = 'Assessor with email {} not found'
+COMPANY_WITH_EMAIL_NOT_EXIST = 'Company with email {} not found'
 
 REGISTER_COMPANY_URL = '/users/register-company/'
 REGISTER_ASSESSEE_URL = '/users/register-assessee/'
@@ -1576,3 +1577,18 @@ class SeparateLoginTest(TestCase):
             self.fail(EXCEPTION_NOT_RAISED)
         except ObjectDoesNotExist as exception:
             self.assertEqual(str(exception), ASSESSOR_WITH_EMAIL_NOT_EXIST.format(invalid_email))
+
+    def test_get_company_from_email_when_exist(self):
+        try:
+            user = utils.get_company_from_email(email=self.company.email)
+            self.assertEquals(user, self.company)
+        except Exception as exception:
+            self.fail(f'{exception} is raised')
+
+    def test_get_company_from_email_when_not_exist(self):
+        invalid_email = 'invalidemail1581@gmail.com'
+        try:
+            utils.get_company_from_email(email=invalid_email)
+            self.fail(EXCEPTION_NOT_RAISED)
+        except ObjectDoesNotExist as exception:
+            self.assertEqual(str(exception), COMPANY_WITH_EMAIL_NOT_EXIST.format(invalid_email))

--- a/users/urls.py
+++ b/users/urls.py
@@ -7,6 +7,7 @@ from .views import (
     serve_register_assessor,
     serve_get_user_info,
     generate_assessor_one_time_code,
+    serve_login_assessor_company
 )
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
@@ -22,5 +23,6 @@ urlpatterns = [
     path('google/oauth/register/assessee/', serve_google_register_assessee),
     path('register-assessee/', serve_register_assessee),
     path('generate-code/', generate_assessor_one_time_code),
-    path('get-info/', serve_get_user_info)
+    path('get-info/', serve_get_user_info),
+    path('login/assessor-company/', serve_login_assessor_company, name='login-assessor-company'),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -150,3 +150,16 @@ def generate_assessor_one_time_code(request):
 def serve_get_user_info(request):
     response_data = get_user_info(request.user)
     return Response(data=response_data)
+
+
+@require_POST
+@api_view(['POST'])
+def serve_login_assessor_company(request):
+    """
+    This view will return the refresh and access token for an assessor or company.
+    ----------------------------------------------------------
+    request-data must contain:
+    email: string
+    password: string
+    """
+    return Response(data=None)

--- a/users/views.py
+++ b/users/views.py
@@ -17,6 +17,7 @@ from .services.google_login import (
     register_assessee_with_google_data
 )
 from .services.user_info import get_user_info
+from .services.login import login_assessor_company
 from one_day_intern.settings import (
     GOOGLE_AUTH_LOGIN_REDIRECT_URI,
     GOOGLE_AUTH_REGISTER_ASSESSEE_REDIRECT_URI,
@@ -162,4 +163,6 @@ def serve_login_assessor_company(request):
     email: string
     password: string
     """
-    return Response(data=None)
+    request_data = json.loads(request.body.decode('utf-8'))
+    token = login_assessor_company(request_data)
+    return Response(data=token, status=200)


### PR DESCRIPTION
### Describe your changes
Create new endpoint to login users as assessors or companies. This end-point substitute the one provided by django rest framework. 

### Backlog name
PBI-07-company_assessor_login

### Acceptance criteria

- User can login as assessor or company by submitting correct credentials.
- System will return a 401 code when credentials are invalid and when user is an assessee.

### Request
#### Login Assessor and Company
URL: http://localhost:8000/users/login/assessor-company/
Request Type: POST
Request data: email (string), password (string)
Example Request Body:
```
{
    "email": "email@email.com",
    "password": "password123"
}
```
### Checklist
- [X] I have performed a self-review of my code
- [X] Code successfully run on local
- [X] Feature / changes tested on local
- [X]  No failing unit test
- [ ]  Passed UAT Test
- [X]  Sonarqube tested
- [ ]  Required any changes to environment variable