### PR TITLE
PBI-20: Get Assessors of Company

### DIFF
--- a/company/services/company.py
+++ b/company/services/company.py
@@ -11,3 +11,9 @@ def get_company_or_raise_exception(user: User):
         return found_companies[0]
     else:
         raise RestrictedAccessException(f'User {user_email} is not a company')
+
+
+def get_company_assessors(user):
+    company = assessment_utils.get_company_or_assessor_associated_company_from_user(user)
+    assessors = company.get_assessors()
+    return assessors

--- a/company/services/company.py
+++ b/company/services/company.py
@@ -1,3 +1,4 @@
+from assessment.services import utils as assessment_utils
 from django.contrib.auth.models import User
 from one_day_intern.exceptions import RestrictedAccessException
 from users.models import Company

--- a/company/tests.py
+++ b/company/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from unittest.mock import patch
 from django.core import mail
+from django.shortcuts import reverse
 from django.core.mail.backends.smtp import EmailBackend
 from rest_framework.test import APIClient
 from .services import utils, one_time_code, company as company_service
@@ -9,6 +10,8 @@ from users.models import (
     CompanySerializer,
     CompanyOneTimeLinkCode,
     Assessor,
+    Assessee,
+    AssessorSerializer,
     AuthenticationService
 )
 from one_day_intern.exceptions import RestrictedAccessException, InvalidRequestException
@@ -297,3 +300,51 @@ class OneTimeCodeTest(TestCase):
             message=expected_message,
             mocked_send_mass_html_mail=mocked_send_mass_html_mail
         )
+
+
+class CompanyAssessorsTest(TestCase):
+    def setUp(self) -> None:
+        self.assessee = Assessee.objects.create_user(
+            email='assessee308@email.com',
+            password='Password309',
+            first_name='Assessee 310',
+            last_name='Assessee 311',
+            phone_number='+628231233312',
+            authentication_service=AuthenticationService.DEFAULT.value
+        )
+
+        self.company_with_assessor = Company.objects.create_user(
+            email='company305@email.com',
+            password='Password306',
+            company_name='Company 305',
+            description='Description 308',
+            address='Address 309'
+        )
+
+        self.company_without_assessor = Company.objects.create_user(
+            email='company315@email.com',
+            password='Password316',
+            company_name='Company 315',
+            description='Description 318',
+            address='Address 319'
+        )
+
+        self.assessor = Assessor.objects.create_user(
+            email='Assessor334@email.com',
+            password='Password335',
+            first_name='Assessor 313',
+            last_name='Assessor 314',
+            phone_number='+628231234315',
+            employee_id='AEM19316',
+            associated_company=self.company_with_assessor,
+            authentication_service=AuthenticationService.DEFAULT.value
+        )
+
+    def test_get_assessors_when_company_has_assessor(self):
+        assessors = self.company_with_assessor.get_assessors()
+        self.assertEqual(len(assessors), 1)
+        self.assertEqual(assessors[0], self.assessor)
+
+    def test_get_assessors_when_company_has_no_assessor(self):
+        assessors = self.company_without_assessor.get_assessors()
+        self.assertEqual(len(assessors), 0)

--- a/company/urls.py
+++ b/company/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import serve_send_one_time_code_to_assessors
+from .views import serve_send_one_time_code_to_assessors, serve_get_company_assessors
 
 
 urlpatterns = [
-    path('one-time-code/generate/', serve_send_one_time_code_to_assessors)
+    path('one-time-code/generate/', serve_send_one_time_code_to_assessors),
+    path('assessors/', serve_get_company_assessors, name='get-company-assessors'),
 ]

--- a/company/views.py
+++ b/company/views.py
@@ -2,7 +2,9 @@ from django.views.decorators.http import require_POST, require_GET
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from users.models import AssessorSerializer
 from .services.one_time_code import send_one_time_code_to_assessors
+from .services.company import get_company_assessors
 import json
 
 
@@ -35,4 +37,6 @@ def serve_get_company_assessors(request):
     assessors.
     ----------------------------------------------------------
     """
-    return Response(data=None, status=200)
+    company_assessors = get_company_assessors(request.user)
+    response_data = AssessorSerializer(company_assessors, many=True).data
+    return Response(data=response_data, status=200)

--- a/company/views.py
+++ b/company/views.py
@@ -1,4 +1,4 @@
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_POST, require_GET
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -24,3 +24,15 @@ def serve_send_one_time_code_to_assessors(request):
     request_data = json.loads(request.body.decode('utf-8'))
     send_one_time_code_to_assessors(request_data, request.user)
     return Response(data={'message': 'Invitations has been sent'})
+
+
+@require_GET
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def serve_get_company_assessors(request):
+    """
+    This view will serve as the end-point for assessor/company to get all registered
+    assessors.
+    ----------------------------------------------------------
+    """
+    return Response(data=None, status=200)

--- a/users/models.py
+++ b/users/models.py
@@ -31,6 +31,9 @@ class Company(OdiUser):
     description = models.TextField()
     address = models.TextField(null=False)
 
+    def get_assessors(self):
+        return None
+
 
 class CompanySerializer(serializers.ModelSerializer):
     class Meta:
@@ -61,7 +64,7 @@ class AssessorSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Assessor
-        fields = ['first_name', 'last_name', 'phone_number', 'employee_id', 'company_id']
+        fields = ['email', 'first_name', 'last_name', 'phone_number', 'employee_id', 'company_id']
 
 
 class Assessee(OdiUser):
@@ -75,13 +78,9 @@ class Assessee(OdiUser):
         default=AuthenticationService.DEFAULT.value
     )
 
-class AssesseeSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Assessee
-        fields = ['email','first_name', 'last_name', 'phone_number', 'date_of_birth']
 
 class AssesseeSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = Assessee
         fields = ['email', 'first_name', 'last_name', 'phone_number', 'date_of_birth']

--- a/users/models.py
+++ b/users/models.py
@@ -32,7 +32,7 @@ class Company(OdiUser):
     address = models.TextField(null=False)
 
     def get_assessors(self):
-        return None
+        return self.assessor_set.all()
 
 
 class CompanySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
### Describe your changes
Create a new endpoint for assessor or company to get the list of assessors of the company.

### Backlog name
PBI-20-get_assessors_of_company


### Acceptance criteria
- The system must reject the request when the accessing user is an assessee.
- The system must return the list of assessors associated with the company of the accessing assessor.
- The system must return the list of assessors associated with the company when the accessing user is a company.

### Request
URL: http://localhost:8000/company/assessors/
Request Type: GET
Example Request URL:
```
http://localhost:8000/company/assessors/
```

### Checklist
- [X] I have performed a self-review of my code
- [X] Code successfully run on local
- [X] Feature / changes tested on local
- [X]  No failing unit test
- [ ]  Passed UAT Test
- [X]  Sonarqube tested
- [ ]  Required any changes to environment variable